### PR TITLE
rework menu #5

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,37 @@
+# _data/navigation.yml
+main:
+  - title: "Events"
+    url: "#events"
+    submenu:
+      - title: "Barcamp"
+        url: "/dracor-summit/barcamp"
+      - title: "Opening Keynote"
+        url: "/dracor-summit/opening_keynote"
+      - title: "DraCor Corpora Conference"
+        url: "/dracor-summit/corpora_conference"
+      - title: "DraCorOS Training Sessions"
+        url: "/dracor-summit/dracoros_training_sessions"
+      - title: "Open Co-Working"
+        url: "/dracor-summit/open_coworking"
+
+  - title: "Call for Papers"
+    url: "#cfp"
+    submenu:
+      - title: "CfP: Drama Analysis Workshop"
+        url: "/dracor-summit/cfp-drama-analysis"
+      - title: "CfP: Corpora Conference"
+        url: "/dracor-summit/cfp-corpora-conference"
+
+  - title: "Information"
+    url: "#info"
+    submenu:
+      - title: "Programme Overview"
+        url: "/dracor-summit/programme-overview"
+      - title: "Registration"
+        url: "/dracor-summit/registration"
+      - title: "Travel Information"
+        url: "/dracor-summit/travel"
+      - title: "Venue"
+        url: "/dracor-summit/venue"
+      - title: "Bursaries"
+        url: "/dracor-summit/bursaries"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,31 +1,55 @@
 <header class="site-header" role="banner">
-
   <div class="wrapper">
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
-    <a class="site-logo" rel="author" href="{{ "/" | relative_url }}"><img alt="DraCor Summit Logo" src="{{ "/assets/DraCor-Summit-Logo.svg" | relative_url }}"></a>
+    
+    <a class="site-logo" rel="author" href="{{ "/" | relative_url }}">
+      <img alt="DraCor Summit Logo" src="{{ "/assets/DraCor-Summit-Logo.svg" | relative_url }}">
+    </a>
     <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
 
-    {%- if page_paths -%}
-      <nav class="site-nav">
-        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-        <label for="nav-trigger">
-          <span class="menu-icon">
-            <svg viewBox="0 0 18 15" width="18px" height="15px">
-              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
-            </svg>
-          </span>
-        </label>
+    <nav class="site-nav">
+      <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+      <label for="nav-trigger">
+        <span class="menu-icon">
+          <svg viewBox="0 0 18 15" width="18px" height="15px">
+            <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+          </svg>
+        </span>
+      </label>
 
-        <div class="trigger">
-          {%- for path in page_paths -%}
-            {%- assign my_page = site.pages | where: "path", path | first -%}
-            {%- if my_page.title -%}
-            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+      <div class="trigger">
+        {%- if site.data.navigation.main -%}
+          {%- for item in site.data.navigation.main -%}
+            {%- if item.submenu -%}
+              <div class="nav-item has-submenu">
+                <a class="page-link" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+                <div class="submenu">
+                  {%- for subitem in item.submenu -%}
+                    <a class="page-link" href="{{ subitem.url | relative_url }}">{{ subitem.title }}</a>
+                  {%- endfor -%}
+                </div>
+              </div>
+            {%- else -%}
+              <div class="nav-item">
+                <a class="page-link" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+              </div>
             {%- endif -%}
           {%- endfor -%}
-        </div>
-      </nav>
-    {%- endif -%}
+        {%- else -%}
+          {%- comment -%} Fallback to original navigation if navigation.yml doesn't exist {%- endcomment -%}
+          {%- if page_paths -%}
+            {%- for path in page_paths -%}
+              {%- assign my_page = site.pages | where: "path", path | first -%}
+              {%- if my_page.title -%}
+                <div class="nav-item">
+                  <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+                </div>
+              {%- endif -%}
+            {%- endfor -%}
+          {%- endif -%}
+        {%- endif -%}
+      </div>
+    </nav>
   </div>
 </header>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -14,7 +14,7 @@
     </main>
 
     {%- include footer.html -%}
-
+    <script src="{{ '/assets/js/navigation.js' | relative_url }}"></script>
   </body>
 
 </html>

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -1,3 +1,5 @@
+---
+---
 $main: #1f2448;             // Dark blue
 $background: #ebf0f7;       // Light blue
 $primary-accent: #0088ff;   // Bright blue
@@ -34,10 +36,123 @@ a {
     background-color: $main;
     border: none;
 
+    // Navigation items container
+    .trigger {
+      display: flex;
+      align-items: center;
+    }
+
+    // Individual navigation items
+    .nav-item {
+      position: relative;
+      
+      // Add dropdown arrow for items with submenus
+      &.has-submenu > .page-link::after {
+        content: ' ▼';
+        font-size: 0.8em;
+        margin-left: 5px;
+      }
+    }
+
+    // Submenu dropdown styles
+    .submenu {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      background: white;
+      min-width: 250px;
+      box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+      border: 1px solid #ddd;
+      border-radius: 3px;
+      opacity: 0;
+      visibility: hidden;
+      transform: translateY(-10px);
+      transition: all 0.3s ease;
+      z-index: 1000;
+
+      .page-link {
+        color: $main !important; // Override white color for submenu
+        margin: 0;
+        padding: 12px 20px;
+        border-bottom: 1px solid #f0f0f0;
+        font-size: 0.9em;
+        white-space: nowrap;
+        display: block;
+
+        &:last-child {
+          border-bottom: none;
+        }
+
+        &:hover {
+          background: $primary-accent;
+          color: white !important;
+          text-decoration: none;
+        }
+      }
+    }
+
+    // Show submenu on hover
+    .nav-item:hover .submenu {
+      opacity: 1;
+      visibility: visible;
+      transform: translateY(0);
+    }
+
     @media screen and (max-width: 600px) {
       top: auto;
       right: 8px;
       margin-top: 8px;
+
+      .trigger {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .nav-item {
+        width: 100%;
+        
+        &.has-submenu > .page-link::after {
+          content: ' +';
+          float: right;
+        }
+      }
+
+      .page-link {
+        display: block;
+        padding: 10px 15px;
+        border-bottom: 1px solid rgba(255,255,255,0.1);
+      }
+
+      .submenu {
+        position: static;
+        box-shadow: none;
+        border: none;
+        border-radius: 0;
+        opacity: 1;
+        visibility: visible;
+        transform: none;
+        background: rgba(0,0,0,0.1);
+        max-height: 0;
+        overflow: hidden;
+        transition: max-height 0.3s ease;
+
+        .page-link {
+          color: rgba(255,255,255,0.8) !important;
+          padding-left: 30px;
+          background: rgba(0,0,0,0.1);
+          border-bottom: 1px solid rgba(255,255,255,0.05);
+
+          &:hover {
+            background: rgba(255,255,255,0.1);
+            color: white !important;
+          }
+        }
+      }
+
+      .nav-item:hover .submenu,
+      .nav-item.mobile-active .submenu {
+        max-height: 300px;
+      }
     }
 
     .menu-icon > svg {

--- a/assets/js/navigation.js
+++ b/assets/js/navigation.js
@@ -1,0 +1,62 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const hasSubmenuItems = document.querySelectorAll('.has-submenu');
+  
+  function initializeMobileNavigation() {
+    hasSubmenuItems.forEach(item => {
+      const link = item.querySelector('.page-link');
+      const submenu = item.querySelector('.submenu');
+      
+      // Remove existing event listeners
+      const newLink = link.cloneNode(true);
+      link.parentNode.replaceChild(newLink, link);
+      
+      // Add click functionality only on mobile
+      if (window.innerWidth <= 600) {
+        newLink.addEventListener('click', function(e) {
+          e.preventDefault();
+          item.classList.toggle('mobile-active');
+          
+          // Close other submenus
+          hasSubmenuItems.forEach(otherItem => {
+            if (otherItem !== item) {
+              otherItem.classList.remove('mobile-active');
+            }
+          });
+        });
+      }
+    });
+  }
+
+  // Initialize on page load
+  initializeMobileNavigation();
+
+  // Re-initialize on window resize
+  let resizeTimer;
+  window.addEventListener('resize', function() {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(function() {
+      // Remove mobile-active class when switching to desktop
+      if (window.innerWidth > 600) {
+        hasSubmenuItems.forEach(item => {
+          item.classList.remove('mobile-active');
+        });
+      }
+      initializeMobileNavigation();
+    }, 250);
+  });
+
+  // Close mobile menu when clicking outside
+  document.addEventListener('click', function(e) {
+    if (window.innerWidth <= 600) {
+      const nav = document.querySelector('.site-nav');
+      const navTrigger = document.getElementById('nav-trigger');
+      
+      if (!nav.contains(e.target)) {
+        navTrigger.checked = false;
+        hasSubmenuItems.forEach(item => {
+          item.classList.remove('mobile-active');
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
This was all vibe coded, so please test @lehkost et al

# Add Responsive Navigation with Submenus

## Summary
Implemented a data-driven responsive navigation system with dropdown submenus to improve site organization and user experience.

## Changes Made

### 📁 **New Files**
- `_data/navigation.yml` - Navigation structure configuration
- `assets/js/navigation.js` - Mobile submenu functionality

### 🔧 **Modified Files**
- `_includes/header.html` - Updated to use data-driven navigation with Liquid templating
- `assets/css/custom.scss` - Added submenu styles and responsive behavior
- `_layouts/base.html` - Added JavaScript include for navigation functionality

## Features Added

### 🖥️ **Desktop Navigation**
- Hover-activated dropdown submenus
- Smooth fade and slide animations
- Visual indicators (▼) for items with submenus

### 📱 **Mobile Navigation**
- Tap-to-expand submenu functionality
- Collapsible hamburger menu (existing)
- Touch-friendly sizing and spacing
- Auto-close when clicking outside menu

### 🎨 **Design**
- Maintains existing color scheme and branding
- Organized navigation into logical categories:
  - **Events** (Barcamp, Keynote, Conference, etc.)
  - **Call for Papers** (Drama Analysis, Corpora Conference)
  - **Information** (Registration, Travel, Venue, etc.)

## Technical Implementation
- **Data-driven**: Easy to maintain through YAML configuration
- **Jekyll-friendly**: Uses proper Liquid templating and relative URLs
- **Backwards compatible**: Fallback to original navigation if YAML is missing
- **Responsive**: Adapts behavior based on screen size (600px breakpoint)

## Testing
- [ ] Desktop hover functionality
- [ ] Mobile tap functionality  
- [ ] Responsive design across screen sizes
- [ ] Navigation structure matches original pages
- [ ] Maintains existing styling and branding

## How to Test
1. **Desktop**: Hover over "Events", "Call for Papers", or "Information" to see submenus
2. **Mobile**: Tap hamburger menu, then tap items with "+" to expand submenus
3. **Responsive**: Resize browser window to test behavior transitions